### PR TITLE
Fixed metadata not loading for modded music

### DIFF
--- a/modules/musicviewer_four_metalookup.py
+++ b/modules/musicviewer_four_metalookup.py
@@ -5,11 +5,7 @@ import os.path
 _EXTRACT_FIELDS = ['title','artist','album']
 
 def _extract_meta(file):
-    try:
-        filepath = renpy.loader.transfn(file)
-    except:
-        filepath = file
-    refs = TinyTag.get((filepath), duration=False, ignore_errors=True)
+    refs = TinyTag.get((file), duration=False, ignore_errors=True)
     meta = {field:getattr(refs,field) for field in _EXTRACT_FIELDS if hasattr(refs,field) and getattr(refs,field)}
 
     if not meta:

--- a/modules/tinytag/tinytag.py
+++ b/modules/tinytag/tinytag.py
@@ -49,6 +49,7 @@ import sys
 from io import BytesIO
 import re
 import renpy.loader
+import renpy.config
 
 DEBUG = os.environ.get('DEBUG', False)  # some of the parsers can print debug info
 
@@ -180,9 +181,14 @@ class TinyTag(object):
             pass
         else:
             filename = os.path.expanduser(filename)
-        if not renpy.loader.loadable(filename):
+        try:
+            rel_filename = filename
+            filename = renpy.loader.transfn(filename)
+        except Exception:
+            pass
+        if not renpy.loader.loadable(rel_filename):
             return TinyTag(None, 0)
-        with renpy.loader.load(filename) as af:
+        with renpy.loader.load(rel_filename) as af:
             size = af.length if isinstance(af, renpy.loader.SubFile) else os.path.getsize(filename)
             parser_class = cls.get_parser_class(filename, af)
             tag = parser_class(af, size, ignore_errors=ignore_errors)


### PR DESCRIPTION
Metadata wasn't loading for modded music, because Ren'Py loader needs relative resource path, not absolute path. It works just fine now.